### PR TITLE
Add start screen and Sudoku board

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,10 @@ android {
         jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.jae.a.sudoku"
@@ -41,4 +45,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation("androidx.appcompat:appcompat:1.6.1")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,13 @@
         android:label="sudoku"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <activity android:name=".ui.StartActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <activity android:name=".ui.SudokuActivity" android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -12,18 +19,9 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- Specifies an Android theme to apply to this Activity as soon as
-                 the Android process has started. This theme is visible to the user
-                 while the Flutter UI initializes. After that, this theme continues
-                 to determine the Window background behind the Flutter UI. -->
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
+              android:resource="@style/NormalTheme" />
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/app/src/main/kotlin/com/jae/a/sudoku/ui/StartActivity.kt
+++ b/app/src/main/kotlin/com/jae/a/sudoku/ui/StartActivity.kt
@@ -1,0 +1,21 @@
+package com.jae.a.sudoku.ui
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.jae.a.sudoku.databinding.ActivityStartBinding
+
+class StartActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityStartBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityStartBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.startButton.setOnClickListener {
+            val intent = Intent(this, SudokuActivity::class.java)
+            startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jae/a/sudoku/ui/SudokuActivity.kt
+++ b/app/src/main/kotlin/com/jae/a/sudoku/ui/SudokuActivity.kt
@@ -1,0 +1,31 @@
+package com.jae.a.sudoku.ui
+
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.jae.a.sudoku.databinding.ActivitySudokuBinding
+
+class SudokuActivity : AppCompatActivity() {
+    private lateinit var binding: ActivitySudokuBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySudokuBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // Simple 9x9 grid with placeholder numbers
+        repeat(9) { row ->
+            repeat(9) { col ->
+                val cell = TextView(this).apply {
+                    text = ""
+                    gravity = Gravity.CENTER
+                    width = resources.displayMetrics.density.times(40).toInt()
+                    height = width
+                    setBackgroundResource(android.R.drawable.alert_light_frame)
+                }
+                binding.grid.addView(cell)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_start.xml
+++ b/app/src/main/res/layout/activity_start.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/startButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start Game" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_sudoku.xml
+++ b/app/src/main/res/layout/activity_sudoku.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/grid"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:columnCount="9"
+    android:rowCount="9"
+    android:padding="16dp">
+</GridLayout>


### PR DESCRIPTION
## Summary
- add start screen activity with a button
- add Sudoku activity with simple 9x9 grid
- enable viewBinding and add appcompat dependency
- register new activities in manifest

## Testing
- `./gradlew test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685658d00678832fb293e57a5113e4aa